### PR TITLE
Refactor/queue scheduling

### DIFF
--- a/src/main/kotlin/com/example/integrated/queue/queue/QueueController.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/QueueController.kt
@@ -16,20 +16,17 @@ class QueueController (
 
     private val queueService: QueueService
 ): Loggable {
-    // 대기열에 사용자 등록, 대기열 신규 진입 시 X-Queue-Seq 헤더로 번호표 노출
+    // 대기열에 사용자 등록, wait/allow 진입 여부는 응답 enum으로 노출
     @PostMapping("/register")
     suspend fun registerUser(
         @RequestBody request: QueueRequest,
-        response: ServerHttpResponse
     ): RegisterResult {
         val queueType = request.queueType
         val userId = request.userId
 
         log.info { "대기열 등록 요청 : server=$serverName, userId=$userId, queueType=$queueType" }
 
-        val (result, seq) = queueService.registerUserToWaitQueue(queueType, userId)
-        seq?.let { response.headers.add("X-Queue-Seq", it.toString()) }
-        return result
+        return queueService.registerUserToWaitQueue(queueType, userId)
     }
 
     // 대기열에서의 사용자 순위 조회

--- a/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
@@ -2,7 +2,6 @@ package com.example.integrated.queue.queue
 
 import com.example.integrated.queue.queue.dto.QueueChangePayload
 import com.example.integrated.queue.queue.dto.RegisterResult
-import com.example.integrated.queue.queue.scheduler.QueueScheduler
 import com.example.integrated.queue.queue.scheduler.QueueSchedulerService
 import com.example.integrated.redis.pubsub.RedisPublisher
 import com.example.integrated.reserveException.ErrorCode
@@ -31,7 +30,6 @@ class QueueService(
         private val validationKey: String,
 
         private val queueSchedulerService: QueueSchedulerService,
-        private val queueScheduler: QueueScheduler,
         private val redisPublisher: RedisPublisher,
         private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>,
         private val objectMapper: ObjectMapper
@@ -44,16 +42,11 @@ class QueueService(
     ): RegisterResult {
         val code = queueSchedulerService.enqueueOrAllow(queueType, userId)
 
+        // 활성 큐 레지스트리 등록(SADD)은 enqueue-or-allow.lua 내부에서 원자적으로 처리된다.
         return when (code) {
             -1L, -2L -> RegisterResult.ALREADY_EXISTS
-            0L -> {
-                queueScheduler.addActiveQueue(queueType)
-                RegisterResult.REGISTERED_WAIT
-            }
-            else -> {
-                queueScheduler.addActiveQueue(queueType)
-                RegisterResult.REGISTERED_ALLOW
-            }
+            0L -> RegisterResult.REGISTERED_WAIT
+            else -> RegisterResult.REGISTERED_ALLOW
         }
     }
 

--- a/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
@@ -37,22 +37,22 @@ class QueueService(
         private val objectMapper: ObjectMapper
 ) : Loggable {
 
-    // 대기열 등록, 신규 대기열 삽입 시 seq를 함께 반환 (X-Queue-Seq 헤더 노출용)
+    // 대기열 등록, wait/allow 진입 여부를 enum으로 반환
     suspend fun registerUserToWaitQueue(
             queueType: String,
             userId: String
-    ): Pair<RegisterResult, Long?> {
-        val (code, seq) = queueSchedulerService.enqueueOrAllow(queueType, userId)
+    ): RegisterResult {
+        val code = queueSchedulerService.enqueueOrAllow(queueType, userId)
 
         return when (code) {
-            -1L, -2L -> RegisterResult.ALREADY_EXISTS to null
+            -1L, -2L -> RegisterResult.ALREADY_EXISTS
             0L -> {
                 queueScheduler.addActiveQueue(queueType)
-                RegisterResult.REGISTERED to seq
+                RegisterResult.REGISTERED_WAIT
             }
             else -> {
                 queueScheduler.addActiveQueue(queueType)
-                RegisterResult.REGISTERED to null
+                RegisterResult.REGISTERED_ALLOW
             }
         }
     }

--- a/src/main/kotlin/com/example/integrated/queue/queue/dto/RegisterResult.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/dto/RegisterResult.kt
@@ -1,6 +1,7 @@
 package com.example.integrated.queue.queue.dto
 
 enum class RegisterResult {
-    REGISTERED,
+    REGISTERED_WAIT,
+    REGISTERED_ALLOW,
     ALREADY_EXISTS,
 }

--- a/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueScheduler.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueScheduler.kt
@@ -4,7 +4,6 @@ import com.example.integrated.redis.RedisLockUtil
 import com.example.integrated.util.ACTIVE_QUEUE_KEY
 import com.example.integrated.util.Loggable
 import com.example.integrated.util.SCHEDULING_KEY
-import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
@@ -48,11 +47,5 @@ class QueueScheduler(
                 .collectList()
                 .awaitSingleOrNull()
                 ?: emptyList()
-    }
-
-    suspend fun addActiveQueue(queueType: String) {
-        reactiveRedisTemplate.opsForSet()
-                .add(ACTIVE_QUEUE_KEY, queueType)
-                .awaitSingle()
     }
 }

--- a/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueScheduler.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueScheduler.kt
@@ -4,7 +4,6 @@ import com.example.integrated.redis.RedisLockUtil
 import com.example.integrated.util.ACTIVE_QUEUE_KEY
 import com.example.integrated.util.Loggable
 import com.example.integrated.util.SCHEDULING_KEY
-import com.example.integrated.util.WAIT_QUEUE
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.data.redis.core.ReactiveRedisTemplate
@@ -18,23 +17,23 @@ class QueueScheduler(
         private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>,
 ) : Loggable {
 
+    // "이 시스템이 시작된 이후로 한 번이라도 사용자가 진입한 적 있는 큐" 는 모두 스케줄링 대상
     @Scheduled(
             fixedDelayString = "\${queue.allow.interval-ms}",
             initialDelay = 5000
     )
     suspend fun scheduling() {
-        val activeQueues = getActiveQueue()
-        if (activeQueues.isEmpty()) return
+        val knownQueues = getKnownQueues()
+        if (knownQueues.isEmpty()) return
 
         redisLockUtil.acquireLockAndRun(SCHEDULING_KEY) {
-            activeQueues.forEach { queueType ->
+            knownQueues.forEach { queueType ->
                 try {
                     // Lua 스크립트 하나로 만료 정리 + 빈 자리 계산 + 승격을 원자적으로 처리
+                    // 빈 큐는 Lua 내부에서 즉시 count=0 으로 리턴되므로 별도 정리 분기 불필요
                     val count = queueSchedulerService.promoteUsers(queueType)
-                    log.info { "$queueType 허용열로 이동한 사용자 : $count" }
-
-                    if (count == 0L && getWaitQueueSize(queueType) == 0L) {
-                        removeActiveQueue(queueType)
+                    if (count > 0L) {
+                        log.info { "$queueType 허용열로 이동한 사용자 : $count" }
                     }
                 } catch (e: Exception) {
                     log.error(e) { "스케줄링 중 예외 발생 - ${e.message}" }
@@ -43,7 +42,7 @@ class QueueScheduler(
         }
     }
 
-    suspend fun getActiveQueue(): List<String> {
+    suspend fun getKnownQueues(): List<String> {
         return reactiveRedisTemplate.opsForSet()
                 .members(ACTIVE_QUEUE_KEY)
                 .collectList()
@@ -51,21 +50,9 @@ class QueueScheduler(
                 ?: emptyList()
     }
 
-    private suspend fun getWaitQueueSize(queueType: String): Long {
-        return reactiveRedisTemplate.opsForZSet()
-                .size("$queueType$WAIT_QUEUE")
-                .awaitSingle()
-    }
-
     suspend fun addActiveQueue(queueType: String) {
         reactiveRedisTemplate.opsForSet()
                 .add(ACTIVE_QUEUE_KEY, queueType)
-                .awaitSingle()
-    }
-
-    suspend fun removeActiveQueue(queueType: String) {
-        reactiveRedisTemplate.opsForSet()
-                .remove(ACTIVE_QUEUE_KEY, queueType)
                 .awaitSingle()
     }
 }

--- a/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
@@ -2,6 +2,7 @@ package com.example.integrated.queue.queue.scheduler
 
 import com.example.integrated.queue.queue.dto.QueueChangePayload
 import com.example.integrated.redis.pubsub.RedisPublisher
+import com.example.integrated.util.ACTIVE_QUEUE_KEY
 import com.example.integrated.util.ALLOW_QUEUE
 import com.example.integrated.util.CHANNEL_NAME
 import com.example.integrated.util.WAIT_QUEUE
@@ -57,13 +58,15 @@ class QueueSchedulerService(
 
         val keys = listOf(
                 "$queueType$ALLOW_QUEUE",   // KEYS[1] : 참가열 키
-                "$queueType$WAIT_QUEUE"     // KEYS[2] : 대기열 키
+                "$queueType$WAIT_QUEUE",    // KEYS[2] : 대기열 키
+                ACTIVE_QUEUE_KEY            // KEYS[3] : 활성 큐 레지스트리
         )
 
         val args = listOf(
                 maxCapacity.toString(),     // ARGV[1] : 참가열 최대 수용 인원
                 nowMs.toString(),           // ARGV[2] : 현재 시각 ( 만료 판단 )
-                expireAt.toString()         // ARGV[3] : 참가열 score
+                expireAt.toString(),        // ARGV[3] : 참가열 score
+                queueType                   // ARGV[4] : 레지스트리 멤버
         )
 
         val raw = reactiveRedisTemplate.execute(SCHEDULE_PROMOTE_SCRIPT, keys, args)
@@ -100,14 +103,16 @@ class QueueSchedulerService(
         val keys = listOf(
                 "$queueType$ALLOW_QUEUE",       // KEYS[1] : 참가열 키
                 "$queueType$WAIT_QUEUE",        // KEYS[2] : 대기열 키
-                "queue:seq:$queueType"          // KEYS[3] : 이벤트별 시퀀스 카운터 키 ( score 생성용 )
+                "queue:seq:$queueType",         // KEYS[3] : 이벤트별 시퀀스 카운터 키 ( score 생성용 )
+                ACTIVE_QUEUE_KEY                // KEYS[4] : 활성 큐 레지스트리
         )
 
         val args = listOf(
                 userId,                         // ARGV[1] : userId
                 maxCapacity.toString(),         // ARGV[2] : 참가열 최대 수용 인원
                 nowMs.toString(),               // ARGV[3] : 현재 시각
-                expireAt.toString()             // ARGV[4] : 참가열 score
+                expireAt.toString(),            // ARGV[4] : 참가열 score
+                queueType                       // ARGV[5] : 레지스트리 멤버
         )
 
         return reactiveRedisTemplate.execute(ENQUEUE_OR_ALLOW_SCRIPT, keys, args)
@@ -120,10 +125,11 @@ class QueueSchedulerService(
     suspend fun cancelUser(queueType: String, userId: String): String {
         val keys = listOf(
                 "$queueType$WAIT_QUEUE",    // KEYS[1] : 대기열 키
-                "$queueType$ALLOW_QUEUE"    // KEYS[2] : 참가열 키
+                "$queueType$ALLOW_QUEUE",   // KEYS[2] : 참가열 키
+                ACTIVE_QUEUE_KEY           // KEYS[3] : 활성 큐 레지스트리
         )
 
-        val args = listOf(userId)           // ARGV[1] : userId
+        val args = listOf(userId, queueType)   // ARGV[1] : userId, ARGV[2] : 레지스트리 멤버
 
         return reactiveRedisTemplate.execute(CANCEL_USER_SCRIPT, keys, args)
                 .next()

--- a/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
@@ -14,12 +14,14 @@ import org.springframework.core.io.ClassPathResource
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Service
-import java.time.Duration
 
 @Service
 class QueueSchedulerService(
         @Value("\${queue.allow.max-capacity}")
         private val maxCapacity: Long,
+
+        @Value("\${queue.allow.token-ttl-ms}")
+        private val tokenTtlMs: Long,
 
         private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>,
         private val redisPublisher: RedisPublisher,
@@ -27,10 +29,10 @@ class QueueSchedulerService(
 ) : Loggable {
 
     companion object {
-        // Consumer용 : 중복 체크 + score 생성 + 참가열/대기열 삽입을 원자적으로 수행, {result, seq} 반환
-        private val ENQUEUE_OR_ALLOW_SCRIPT: RedisScript<List<*>> = RedisScript.of(
+        // Consumer용 : 중복 체크 + score 생성 + 참가열/대기열 삽입을 원자적으로 수행, 단일 정수 반환
+        private val ENQUEUE_OR_ALLOW_SCRIPT: RedisScript<Long> = RedisScript.of(
                 ClassPathResource("scripts/enqueue-or-allow.lua"),
-                List::class.java
+                Long::class.java
         )
 
         // 스케줄러용 : 만료 정리 + 빈 자리 계산 + 승격을 원자적으로 수행 ( JSON 문자열 반환 )
@@ -48,14 +50,10 @@ class QueueSchedulerService(
         const val EVENT_PROMOTE = "promote"
     }
 
-    private data class PromoteResult(val count: Long, val ids: List<String>)
-
-    data class EnqueueResult(val code: Long, val seq: Long)
-
     // 스케줄러 : 만료 정리 + 빈 자리 계산 + 승격을 원자적으로 처리
     suspend fun promoteUsers(queueType: String): Long {
         val nowMs = System.currentTimeMillis()
-        val expireAt = nowMs + Duration.ofMinutes(10).toMillis()
+        val expireAt = nowMs + tokenTtlMs
 
         val keys = listOf(
                 "$queueType$ALLOW_QUEUE",   // KEYS[1] : 참가열 키
@@ -90,15 +88,14 @@ class QueueSchedulerService(
 
     /**
      * 중복 체크 + score 생성 + 대기열/참가열 삽입을 원자적으로 처리
-     * code: -1 (대기열 존재), -2 (참가열 존재), 1 (참가열 삽입), 0 (대기열 삽입)
-     * seq : 대기열 신규 삽입(code=0)일 때만 > 0, 그 외 0
+     * 반환: -1 (대기열 존재), -2 (참가열 존재), 0 (대기열 삽입), 1 (참가열 삽입)
      */
     suspend fun enqueueOrAllow(
             queueType: String,
             userId: String
-    ): EnqueueResult {
+    ): Long {
         val nowMs = System.currentTimeMillis()
-        val expireAt = nowMs + Duration.ofMinutes(10).toMillis()
+        val expireAt = nowMs + tokenTtlMs
 
         val keys = listOf(
                 "$queueType$ALLOW_QUEUE",       // KEYS[1] : 참가열 키
@@ -113,13 +110,9 @@ class QueueSchedulerService(
                 expireAt.toString()             // ARGV[4] : 참가열 score
         )
 
-        val raw = reactiveRedisTemplate.execute(ENQUEUE_OR_ALLOW_SCRIPT, keys, args)
+        return reactiveRedisTemplate.execute(ENQUEUE_OR_ALLOW_SCRIPT, keys, args)
                 .next()
                 .awaitSingle()
-
-        val code = (raw[0] as Number).toLong()
-        val seq = (raw[1] as Number).toLong()
-        return EnqueueResult(code, seq)
     }
 
     // 취소 원자적 처리 : wait → allow 순서로 ZREM, 어느 쪽에서 제거됐는지 반환
@@ -136,4 +129,6 @@ class QueueSchedulerService(
                 .next()
                 .awaitSingle()
     }
+
+    private data class PromoteResult(val count: Long, val ids: List<String>)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,8 @@ server.port=8081
 queue.validation.key=park
 
 queue.allow.interval-ms=3000
-queue.allow.max-capacity=200
+queue.allow.max-capacity=400
+queue.allow.token-ttl-ms=600000
 
 spring.redis.sentinel.master=toMaster
 spring.redis.sentinel.nodes=redis-sentinel01:26379,redis-sentinel02:26379,redis-sentinel03:26379

--- a/src/main/resources/scripts/cancel-user.lua
+++ b/src/main/resources/scripts/cancel-user.lua
@@ -2,8 +2,10 @@
 --
 -- KEYS[1] : 대기열 키 (ZSet)
 -- KEYS[2] : 참가열 키 (ZSet)
+-- KEYS[3] : 활성 큐 레지스트리 키 (active-allow-queue, Set)
 --
 -- ARGV[1] : userId
+-- ARGV[2] : queueType (레지스트리 멤버)
 --
 -- 반환 값:
 --   'wait'  : 대기열에서 제거됨
@@ -12,13 +14,24 @@
 
 local waitKey = KEYS[1]
 local allowKey = KEYS[2]
+local activeKey = KEYS[3]
 local userId = ARGV[1]
+local queueType = ARGV[2]
+
+-- 취소로 대기열·참가열이 모두 비면 이 큐는 완전히 소진 → 레지스트리에서 제거
+local function removeIfDrained()
+    if redis.call('ZCARD', waitKey) == 0 and redis.call('ZCARD', allowKey) == 0 then
+        redis.call('SREM', activeKey, queueType)
+    end
+end
 
 if redis.call('ZREM', waitKey, userId) > 0 then
+    removeIfDrained()
     return 'wait'
 end
 
 if redis.call('ZREM', allowKey, userId) > 0 then
+    removeIfDrained()
     return 'allow'
 end
 

--- a/src/main/resources/scripts/enqueue-or-allow.lua
+++ b/src/main/resources/scripts/enqueue-or-allow.lua
@@ -3,11 +3,13 @@
 -- KEYS[1] : 참가열 키 (ZSet)
 -- KEYS[2] : 대기열 키 (ZSet)
 -- KEYS[3] : 시퀀스 카운터 키 (queue:seq:{queueType}, 영구 보존)
+-- KEYS[4] : 활성 큐 레지스트리 키 (active-allow-queue, Set)
 
 -- ARGV[1] : userId
 -- ARGV[2] : 참가열 최대 수용 인원 (maxCapacity)
 -- ARGV[3] : 현재 시각 밀리초 (참가열 만료 정리용)
 -- ARGV[4] : 참가열 score (expireAt)
+-- ARGV[5] : queueType (레지스트리 멤버)
 
 -- 반환 값: 단일 정수
 --   -1 : 대기열 중복
@@ -18,11 +20,13 @@
 local allowKey = KEYS[1]
 local waitKey = KEYS[2]
 local seqKey = KEYS[3]
+local activeKey = KEYS[4]
 
 local userId = ARGV[1]
 local maxCapacity = tonumber(ARGV[2])
 local nowMs = tonumber(ARGV[3])
 local expireAt = tonumber(ARGV[4])
+local queueType = ARGV[5]
 
 -- 1. 대기열에 이미 존재하는지 확인
 if redis.call('ZSCORE', waitKey, userId) then
@@ -44,6 +48,8 @@ local waitCount = redis.call('ZCARD', waitKey)
 --    (여기서 신규 유저를 직행시키면 먼저 온 대기자를 추월 → 선착순 위반)
 if currentCount < maxCapacity and waitCount == 0 then
     redis.call('ZADD', allowKey, expireAt, userId)
+    -- 이 큐에 상태(allow)가 생겼으므로 스케줄링 대상으로 등록
+    redis.call('SADD', activeKey, queueType)
     return 1
 end
 
@@ -51,5 +57,7 @@ end
 --    빈자리는 다음 스케줄러 틱의 ZPOPMIN(선두)이 FIFO 순서대로 채운다.
 local seq = redis.call('INCR', seqKey)
 redis.call('ZADD', waitKey, seq, userId)
+-- 이 큐에 대기자가 생겼으므로 스케줄링 대상으로 등록
+redis.call('SADD', activeKey, queueType)
 
 return 0

--- a/src/main/resources/scripts/enqueue-or-allow.lua
+++ b/src/main/resources/scripts/enqueue-or-allow.lua
@@ -12,8 +12,8 @@
 -- 반환 값: 단일 정수
 --   -1 : 대기열 중복
 --   -2 : 참가열 중복
---    0 : 대기열 신규 삽입
---    1 : 참가열 직접 삽입
+--    0 : 대기열 신규 삽입 (참가열 만석 또는 대기자 존재)
+--    1 : 참가열 직접 삽입 (여유 O + 대기자 X)
 
 local allowKey = KEYS[1]
 local waitKey = KEYS[2]
@@ -34,17 +34,21 @@ if redis.call('ZSCORE', allowKey, userId) then
     return -2
 end
 
--- 3. 참가열에서 만료된 항목 제거 후 현재 인원 확인
+-- 3. 참가열에서 만료된 항목 제거 후 현재 인원 및 대기 인원 확인
 redis.call('ZREMRANGEBYSCORE', allowKey, '-inf', nowMs)
 local currentCount = redis.call('ZCARD', allowKey)
+local waitCount = redis.call('ZCARD', waitKey)
 
--- 4. 참가열에 여유가 있으면 참가열에 직접 삽입
-if currentCount < maxCapacity then
+-- 4. 참가열에 여유가 있고 '대기자가 없을 때만' 참가열에 직접 삽입
+--    대기자가 있으면 빈자리는 반드시 대기열 선두에게 양보해야 FIFO가 유지된다.
+--    (여기서 신규 유저를 직행시키면 먼저 온 대기자를 추월 → 선착순 위반)
+if currentCount < maxCapacity and waitCount == 0 then
     redis.call('ZADD', allowKey, expireAt, userId)
     return 1
 end
 
--- 5. 참가열 여유 없음 → 대기열에 삽입 (INCR 결과를 score로 그대로 사용)
+-- 5. 참가열 만석 또는 대기자 존재 → 대기열에 삽입 (INCR 결과를 score로 그대로 사용)
+--    빈자리는 다음 스케줄러 틱의 ZPOPMIN(선두)이 FIFO 순서대로 채운다.
 local seq = redis.call('INCR', seqKey)
 redis.call('ZADD', waitKey, seq, userId)
 

--- a/src/main/resources/scripts/enqueue-or-allow.lua
+++ b/src/main/resources/scripts/enqueue-or-allow.lua
@@ -1,19 +1,19 @@
 -- 통합 Lua 스크립트: 중복 체크 + score 생성 + 참가열/대기열 삽입을 원자적으로 수행
---
+
 -- KEYS[1] : 참가열 키 (ZSet)
 -- KEYS[2] : 대기열 키 (ZSet)
 -- KEYS[3] : 시퀀스 카운터 키 (queue:seq:{queueType}, 영구 보존)
---
+
 -- ARGV[1] : userId
 -- ARGV[2] : 참가열 최대 수용 인원 (maxCapacity)
 -- ARGV[3] : 현재 시각 밀리초 (참가열 만료 정리용)
 -- ARGV[4] : 참가열 score (expireAt)
---
--- 반환 값: {result, seq}
---   result = -1 : 대기열 중복         (seq = 0)
---   result = -2 : 참가열 중복         (seq = 0)
---   result =  1 : 참가열 직접 삽입    (seq = 0)
---   result =  0 : 대기열 신규 삽입    (seq > 0, 대기열 score 그대로)
+
+-- 반환 값: 단일 정수
+--   -1 : 대기열 중복
+--   -2 : 참가열 중복
+--    0 : 대기열 신규 삽입
+--    1 : 참가열 직접 삽입
 
 local allowKey = KEYS[1]
 local waitKey = KEYS[2]
@@ -26,12 +26,12 @@ local expireAt = tonumber(ARGV[4])
 
 -- 1. 대기열에 이미 존재하는지 확인
 if redis.call('ZSCORE', waitKey, userId) then
-    return {-1, 0}
+    return -1
 end
 
 -- 2. 참가열에 이미 존재하는지 확인
 if redis.call('ZSCORE', allowKey, userId) then
-    return {-2, 0}
+    return -2
 end
 
 -- 3. 참가열에서 만료된 항목 제거 후 현재 인원 확인
@@ -41,11 +41,11 @@ local currentCount = redis.call('ZCARD', allowKey)
 -- 4. 참가열에 여유가 있으면 참가열에 직접 삽입
 if currentCount < maxCapacity then
     redis.call('ZADD', allowKey, expireAt, userId)
-    return {1, 0}
+    return 1
 end
 
 -- 5. 참가열 여유 없음 → 대기열에 삽입 (INCR 결과를 score로 그대로 사용)
 local seq = redis.call('INCR', seqKey)
 redis.call('ZADD', waitKey, seq, userId)
 
-return {0, seq}
+return 0

--- a/src/main/resources/scripts/schedule-promote.lua
+++ b/src/main/resources/scripts/schedule-promote.lua
@@ -2,10 +2,12 @@
 --
 -- KEYS[1] : 참가열 키 (ZSet)
 -- KEYS[2] : 대기열 키 (ZSet)
+-- KEYS[3] : 활성 큐 레지스트리 키 (active-allow-queue, Set)
 --
 -- ARGV[1] : 참가열 최대 수용 인원 (maxCapacity)
 -- ARGV[2] : 현재 시각 밀리초 (만료 판단용)
 -- ARGV[3] : 참가열 score (expireAt)
+-- ARGV[4] : queueType (레지스트리 멤버)
 --
 -- 반환 값: { count, ids } 구조의 JSON 문자열
 --   count : 승격된 사용자 수
@@ -13,10 +15,12 @@
 
 local allowKey = KEYS[1]
 local waitKey = KEYS[2]
+local activeKey = KEYS[3]
 
 local maxCapacity = tonumber(ARGV[1])
 local nowMs = tonumber(ARGV[2])
 local expireAt = tonumber(ARGV[3])
+local queueType = ARGV[4]
 
 local function emptyResult()
     return cjson.encode({ count = 0, ids = {} })
@@ -32,7 +36,13 @@ if vacancy <= 0 then return emptyResult() end
 
 -- 3. 대기열에서 빈 자리만큼 꺼내서 참가열에 삽입
 local waitUsers = redis.call('ZPOPMIN', waitKey, vacancy)
-if #waitUsers == 0 then return emptyResult() end
+if #waitUsers == 0 then
+    -- 대기자 없음. 참가열까지 비었으면(모두 만료) 이 큐는 완전히 소진 → 레지스트리에서 제거
+    if currentCount == 0 then
+        redis.call('SREM', activeKey, queueType)
+    end
+    return emptyResult()
+end
 
 local promotedIds = {}
 for i = 1, #waitUsers, 2 do


### PR DESCRIPTION
- enqueue-or-allow.lua 반환값을 {result, seq}에서 단일 정수로 변경
- 등록 결과를 REGISTERED_WAIT / REGISTERED_ALLOW로 분리하고 Pair 반환 및 X-Queue-Seq 헤더 제거
- 참가열 TTL을 설정값(token-ttl-ms)으로 관리하도록 변경
- QueueSchedulerService의 Lua 스크립트 반환 타입을 RedisScript<List>에서 RedisScript<Long>으로 변경
- QueueScheduler 메서드 리네이밍 및 불필요한 메서드(removeActiveQueue, getWaitQueueSize) 제거
- application.properties에 token-ttl-ms 설정 추가 및 max-capacity를 200에서 400으로 변경