### PR TITLE
refactor SSE promote 팬아웃을 StateFlow/스칼라 payload로 전환하여 이벤트당 O(N²) 제거

### DIFF
--- a/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/QueueService.kt
@@ -63,6 +63,16 @@ class QueueService(
             ?.let { it + 1L }
             ?: -1L
 
+    // 누적 승격 카운터(절대 커서) 조회. init 시점 앵커(A0)로 사용하며, 아직 승격이 없었으면 0 반환
+    suspend fun getAdmittedThrough(
+        queueType: String
+    ): Long =
+        reactiveRedisTemplate.opsForValue()
+            .get("$ADMITTED_COUNTER_KEY_PREFIX$queueType")
+            .awaitFirstOrNull()
+            ?.toLongOrNull()
+            ?: 0L
+
     /* 대기열/참가열 통합 상태 조회 ( 클라이언트 상태 재동기화용 )
     * SSE 재접속 직후 현재 상태를 다시 맞추거나, failover 유실 시 클라이언트가
     * NONE을 보고 재등록을 판단하는 데 사용한다.

--- a/src/main/kotlin/com/example/integrated/queue/queue/dto/QueueChangePayload.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/dto/QueueChangePayload.kt
@@ -3,5 +3,12 @@ package com.example.integrated.queue.queue.dto
 data class QueueChangePayload(
     val queueType: String,
     val event: String,
-    val ids: List<String>
+    val ids: List<String>,
+    // 이 큐에서 지금까지 승격된 누적 인원, 스케줄러가 Lua INCRBY 결과로 채우며, 클라이언트는 rank = R0 - (admittedThrough - A0)로 자기 순번을 체크합니다.
+    // 절대값이라 StateFlow conflation으로 중간 값이 유실돼도 최신 값 하나로 정확도가 유지됩니다.
+    val admittedThrough: Long = 0,
+
+    // StateFlow는 값이 동등하면 방출을 삼키므로, 매 이벤트를 구분하기 위한 단조 증가 시퀀스
+    // 수신 인스턴스가 채우며 발행 측 JSON에는 없어 기본값 0으로 역직렬화됨
+    val seq: Long = 0
 )

--- a/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/queue/scheduler/QueueSchedulerService.kt
@@ -3,6 +3,7 @@ package com.example.integrated.queue.queue.scheduler
 import com.example.integrated.queue.queue.dto.QueueChangePayload
 import com.example.integrated.redis.pubsub.RedisPublisher
 import com.example.integrated.util.ACTIVE_QUEUE_KEY
+import com.example.integrated.util.ADMITTED_COUNTER_KEY_PREFIX
 import com.example.integrated.util.ALLOW_QUEUE
 import com.example.integrated.util.CHANNEL_NAME
 import com.example.integrated.util.WAIT_QUEUE
@@ -57,9 +58,10 @@ class QueueSchedulerService(
         val expireAt = nowMs + tokenTtlMs
 
         val keys = listOf(
-                "$queueType$ALLOW_QUEUE",   // KEYS[1] : 참가열 키
-                "$queueType$WAIT_QUEUE",    // KEYS[2] : 대기열 키
-                ACTIVE_QUEUE_KEY            // KEYS[3] : 활성 큐 레지스트리
+                "$queueType$ALLOW_QUEUE",           // KEYS[1] : 참가열 키
+                "$queueType$WAIT_QUEUE",            // KEYS[2] : 대기열 키
+                ACTIVE_QUEUE_KEY,                   // KEYS[3] : 활성 큐 레지스트리
+                "$ADMITTED_COUNTER_KEY_PREFIX$queueType"  // KEYS[4] : 누적 승격 카운터(절대 커서)
         )
 
         val args = listOf(
@@ -80,7 +82,9 @@ class QueueSchedulerService(
                     QueueChangePayload(
                             queueType = queueType,
                             event = EVENT_PROMOTE,
-                            ids = result.ids
+                            ids = result.ids,
+                            // 누적 승격 인원(절대 커서). 발행 시점에 Lua가 원자적으로 계산한 값을 그대로 싣는다.
+                            admittedThrough = result.admittedThrough
                     )
             )
             redisPublisher.publish(CHANNEL_NAME, payload)
@@ -136,5 +140,5 @@ class QueueSchedulerService(
                 .awaitSingle()
     }
 
-    private data class PromoteResult(val count: Long, val ids: List<String>)
+    private data class PromoteResult(val count: Long, val ids: List<String>, val admittedThrough: Long = 0)
 }

--- a/src/main/kotlin/com/example/integrated/queue/sse/SseEventService.kt
+++ b/src/main/kotlin/com/example/integrated/queue/sse/SseEventService.kt
@@ -5,13 +5,13 @@ import com.example.integrated.queue.queue.dto.QueueChangePayload
 import com.example.integrated.queue.sse.event.CancelledSseEvent
 import com.example.integrated.queue.sse.event.ConfirmSseEvent
 import com.example.integrated.queue.sse.event.ErrorSseEvent
+import com.example.integrated.queue.sse.event.MovedSseEvent
 import com.example.integrated.queue.sse.event.UpdateSseEvent
 import com.example.integrated.util.Loggable
 import com.example.integrated.util.isRedisConnectionException
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
@@ -33,15 +33,13 @@ class SseEventService(
         const val EVENT_INIT = "init"
         const val EVENT_PROMOTE = "promote"
         const val EVENT_CANCEL = "cancel"
+        const val EVENT_NONE = "none"
 
-        private val sinks = ConcurrentHashMap<String, MutableSharedFlow<QueueChangePayload>>()
+        private val sinks = ConcurrentHashMap<String, MutableStateFlow<QueueChangePayload>>()
 
-        fun getSink(queueType: String): MutableSharedFlow<QueueChangePayload> {
+        fun getSink(queueType: String): MutableStateFlow<QueueChangePayload> {
             return sinks.computeIfAbsent(queueType) {
-                // 버퍼가 차면(느린 SSE 소비자) 오래된 이벤트부터 버린다.
-                // 이벤트는 상태가 아니라 재조회 트리거이므로 최신 이벤트를 남기는 쪽이 옳고,
-                // 기본 정책(SUSPEND)에서는 tryEmit이 조용히 실패해 전체 구독자가 이벤트를 잃는다.
-                MutableSharedFlow(extraBufferCapacity = 256, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+                MutableStateFlow(QueueChangePayload(queueType, EVENT_NONE, emptyList()))
             }
         }
     }
@@ -86,11 +84,19 @@ class SseEventService(
                 return sse("cancelled", CancelledSseEvent(userId))
             }
 
-            // 그 외( init 또는 본인 미포함 promote ) : 현재 rank 조회
+            // promote 팬아웃(본인 미포함) : 구독자별 rank를 계산하지 않고 절대 커서만 전송
+            // 클라이언트가 앵커(R0, A0) 기준으로 자기 rank를 갱신하므로, 대용량 rank 맵과 구독자별 재조회가 사라져 StateFlow conflation의 O(N) equals와 GC 압력이 제거됨
+            if (payload.event == EVENT_PROMOTE) {
+                return sse("moved", MovedSseEvent(payload.admittedThrough))
+            }
+
+            // init : 접속자 본인의 현재 rank 1회 조회 (연결당 1회, 팬아웃 아님)
             val rank = queueService.getWaitQueueRank(queueType, userId)
 
             if (rank > 0) {
-                sse("update", UpdateSseEvent(rank))
+                // 앵커용 절대 커서를 rank 다음에 읽습니다.
+                val admittedThrough = queueService.getAdmittedThrough(queueType)
+                sse("update", UpdateSseEvent(rank, admittedThrough))
             } else {
                 // 대기열에 없으면 참가열 확인 (Lua 원자성으로 둘 중 하나에 반드시 존재해야 정상)
                 val isInAllowQueue = !queueService.isAllowTokenExpired(queueType, userId)

--- a/src/main/kotlin/com/example/integrated/queue/sse/event/MovedSseEvent.kt
+++ b/src/main/kotlin/com/example/integrated/queue/sse/event/MovedSseEvent.kt
@@ -1,0 +1,9 @@
+package com.example.integrated.queue.sse.event
+
+// promote 팬아웃 시 대기자 전원에게 보내는 절대 커서
+// 서버가 구독자별 rank를 계산/전송하지 않고 "지금까지 누적 N명 승격됐다"만 브로드캐스트하면,
+// 클라이언트가 init에서 받은 앵커(rank R0, admittedThrough A0)로 rank = R0 - (admittedThrough - A0)를 계산한다.
+// 절대값이라 StateFlow conflation으로 중간 값이 유실돼도 최신 값 하나로 정확도가 유지된다.
+data class MovedSseEvent(
+    val admittedThrough: Long
+)

--- a/src/main/kotlin/com/example/integrated/queue/sse/event/UpdateSseEvent.kt
+++ b/src/main/kotlin/com/example/integrated/queue/sse/event/UpdateSseEvent.kt
@@ -1,5 +1,8 @@
 package com.example.integrated.queue.sse.event
 
+// init 시점의 앵커. rank(R0)와 그때의 절대 커서(admittedThrough=A0)를 함께 내려주면,
+// 클라이언트가 이후 moved 이벤트의 admittedThrough(A)로 rank = R0 - (A - A0)를 계산한다.
 data class UpdateSseEvent(
-    val rank: Long
+    val rank: Long,
+    val admittedThrough: Long
 )

--- a/src/main/kotlin/com/example/integrated/redis/pubsub/RedisMessageListenerService.kt
+++ b/src/main/kotlin/com/example/integrated/redis/pubsub/RedisMessageListenerService.kt
@@ -21,6 +21,7 @@ import org.springframework.data.redis.listener.ReactiveRedisMessageListenerConta
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicLong
 
 @Service
 class RedisMessageListenerService(
@@ -29,6 +30,9 @@ class RedisMessageListenerService(
 ): Loggable {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    // StateFlow 동등성 conflation을 피하기 위한 이벤트 구분용 단조 시퀀스
+    private val seqCounter = AtomicLong(0)
 
     // 애플리케이션 실행 시 pub/sub channel 구독
     @PostConstruct
@@ -59,7 +63,10 @@ class RedisMessageListenerService(
                     .collect { message ->
                         runCatching {
                             val payload = objectMapper.readValue<QueueChangePayload>(message.message)
-                            SseEventService.getSink(payload.queueType).tryEmit(payload)
+                            // 절대 커서(admittedThrough)는 발행 측에서 Lua로 원자 계산해 payload에 이미 실려 있으므로
+                            // 수신 인스턴스는 재계산 없이 그대로 전달한다. StateFlow는 동등 값이면 방출을 삼키므로 단조 seq로 매 이벤트를 구분한다.
+                            SseEventService.getSink(payload.queueType).value =
+                                payload.copy(seq = seqCounter.incrementAndGet())
                         }.onFailure {
                             log.warn { "Pub/Sub 메시지 파싱 실패: ${it.message}, raw=${message.message}" }
                         }

--- a/src/main/kotlin/com/example/integrated/util/AppUtils.kt
+++ b/src/main/kotlin/com/example/integrated/util/AppUtils.kt
@@ -12,6 +12,9 @@ const val CHANNEL_NAME = "queueing_system"
 const val ACTIVE_QUEUE_KEY = "active-allow-queue"
 const val SCHEDULING_KEY = "scheduling-key"
 
+// 큐별 누적 승격 카운터(절대 커서). 실제 키는 "queue:admitted:{queueType}", TTL 없이 영구 보존된다.
+const val ADMITTED_COUNTER_KEY_PREFIX = "queue:admitted:"
+
 inline fun <reified T> ObjectMapper.readValueFromJson(json: String): T {
     return readValue(json, T::class.java)
 }

--- a/src/main/resources/scripts/schedule-promote.lua
+++ b/src/main/resources/scripts/schedule-promote.lua
@@ -3,19 +3,22 @@
 -- KEYS[1] : 참가열 키 (ZSet)
 -- KEYS[2] : 대기열 키 (ZSet)
 -- KEYS[3] : 활성 큐 레지스트리 키 (active-allow-queue, Set)
+-- KEYS[4] : 누적 승격 카운터 키 (queue:admitted:{queueType}, 영구 보존)
 --
 -- ARGV[1] : 참가열 최대 수용 인원 (maxCapacity)
 -- ARGV[2] : 현재 시각 밀리초 (만료 판단용)
 -- ARGV[3] : 참가열 score (expireAt)
 -- ARGV[4] : queueType (레지스트리 멤버)
 --
--- 반환 값: { count, ids } 구조의 JSON 문자열
---   count : 승격된 사용자 수
---   ids   : 승격된 사용자 ID 배열
+-- 반환 값: { count, ids, admittedThrough } 구조의 JSON 문자열
+--   count           : 이번 tick에 승격된 사용자 수
+--   ids             : 승격된 사용자 ID 배열
+--   admittedThrough : 이 큐에서 지금까지 승격된 누적 인원(절대 커서). 클라이언트가 이 값으로 자기 순번을 갱신한다.
 
 local allowKey = KEYS[1]
 local waitKey = KEYS[2]
 local activeKey = KEYS[3]
+local admittedKey = KEYS[4]
 
 local maxCapacity = tonumber(ARGV[1])
 local nowMs = tonumber(ARGV[2])
@@ -51,4 +54,8 @@ for i = 1, #waitUsers, 2 do
     table.insert(promotedIds, waitUsers[i])
 end
 
-return cjson.encode({ count = #promotedIds, ids = promotedIds })
+-- 누적 승격 카운터를 원자적으로 올려 절대 커서를 얻는다. 승격이 실제 일어난 경우에만 증가하므로
+-- StateFlow conflation으로 중간 값이 유실돼도 최신 admittedThrough 하나면 클라이언트가 정확한 순번을 복원한다.
+local admittedThrough = redis.call('INCRBY', admittedKey, #promotedIds)
+
+return cjson.encode({ count = #promotedIds, ids = promotedIds, admittedThrough = admittedThrough })


### PR DESCRIPTION
* SharedFlow의 버퍼 스캔과 대용량 rank 맵 비교로 발생하던 O(N²) 병목을 MutableStateFlow와 스칼라 payload로 개선

* 대기자별 ZRANK 재조회 대신 절대 커서만 브로드캐스트하고, 클라이언트에서 이를 이용해 순번을 계산하도록 변경

* schedule-promote.lua에서 누적 승격 카운터를 원자적으로 증가시켜 절대값을 전송하도록 변경, 중간 이벤트가 유실되어도 최신 값만으로 정확한 순번 유지